### PR TITLE
Update scripts to scrape the ASTRON git and update the local CSVs

### DIFF
--- a/scripts/extract-cabinet-positions.py
+++ b/scripts/extract-cabinet-positions.py
@@ -39,4 +39,4 @@ df[["ETRS-X", "ETRS-Y", "ETRS-Z"]] = geo.xyz_from_geographic(
 for col in "ETRS-X", "ETRS-Y", "ETRS-Z":
     df[col] = df[col].map(lambda x: "{0:.3f}".format(x))
 
-df.to_csv("stationinfo.csv", index=False)
+df.to_csv("../share/lofarantpos/stationinfo-tmp.csv", index=False)

--- a/scripts/extract-etrs-antenna-positions.sh
+++ b/scripts/extract-etrs-antenna-positions.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/bash
 
+# Save working directory
 pushd data
-for fn in `ls *antenna-posi*.csv`; do      STATION=`echo $fn|sed -e 's/\(.*\)-ant.*/\1/'`; cat $fn|egrep -v '^C'|sed -e "s/^/${STATION^^?},/" ; done|grep -v FI |sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*\(,.*,.*\)/\1\2/'|sed -e's/,L/,LBA,/'|sed -e's/,H/,HBA,/' |grep -v NAME |grep BA > ../etrs-antenna-positions-tmp.csv
+
+
+# Remove the previous version of the file
+rm -f ../share/lofarantpos/etrs-antenna-positions-tmp.csv
+
+
+# Parse the files to extract the antenna positions
+echo "STATION,ANTENNA-TYPE,ANTENNA-ID,ETRS-X,ETRS-Y,ETRS-Z,RCU-X,RCU-Y" > ../share/lofarantpos/etrs-antenna-positions-tmp.csv
+for fn in `ls *antenna-posi*.csv`; do
+      STATION=`echo $fn|sed -e 's/\(.*\)-ant.*/\1/'`; 
+      cat $fn|egrep -v '^C'|sed -e "s/^/${STATION^^?},/" ; 
+done 	| grep -v FI |sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*\(,.*,.*\)/\1\2/' \
+		| sed -e's/,L/,LBA,/'|sed -e's/,H/,HBA,/'  \
+		| grep -v NAME  \
+		| grep BA >> ../share/lofarantpos/etrs-antenna-positions-tmp.csv
+
+# Return to original working directory
 popd

--- a/scripts/extract-etrs-phase-centres.sh
+++ b/scripts/extract-etrs-phase-centres.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/bash
 
 pushd data
+
+# Remove the temp file if it already exists
+rm -f ../share/lofarantpos/etrs-phase-centres-tmp.csv
+
+echo "STATION,FIELD,ETRS-X,ETRS-Y,ETRS-Z" > ../share/lofarantpos/etrs-phase-centres-tmp.csv
 for fn in `ls *antenna-posi*.csv`; do 
-    STATION=`echo $fn|sed -e 's/\(.*\)-ant.*/\1/'`; cat $fn|egrep '^C'|sed -e "s/C/${STATION^^?}/" ;
-done|sort -k 1.3,1.9|grep -v FI |sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*,.*,.*/\1/'> etrs-phase-centres-tmp.csv
+    STATION=`echo $fn|sed -e 's/\(.*\)-ant.*/\1/'`; 
+    cat $fn | egrep '^C' \
+    		| sed -e "s/C/${STATION^^?},/" ;
+done	| tr -d ' ' \
+		| sort -k 1.3,1.9 \
+		| grep -v FI \
+		| sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*,.*,.*/\1/' >> ../share/lofarantpos/etrs-phase-centres-tmp.csv
+
 popd

--- a/scripts/extract-etrs-phase-centres.sh
+++ b/scripts/extract-etrs-phase-centres.sh
@@ -13,6 +13,7 @@ for fn in `ls *antenna-posi*.csv`; do
 done	| tr -d ' ' \
 		| sort -k 1.3,1.9 \
 		| grep -v FI \
-		| sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*,.*,.*/\1/' >> ../share/lofarantpos/etrs-phase-centres-tmp.csv
+		| sed -e's/^\(.*,.*,.*,.*\),.*,.*,.*,.*,.*/\1/' \
+		| awk '{split($0,a,","); printf("%s,%s,%.3f,%.3f,%.3f\n", a[1], a[2], a[3], a[4], a[5])}' >> ../share/lofarantpos/etrs-phase-centres-tmp.csv
 
 popd

--- a/scripts/update_all_metadata.sh
+++ b/scripts/update_all_metadata.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Download files if they do not exist
+STATIONS=( CS001 CS002 CS003 CS004 CS005 CS006 CS007 CS011 CS013 CS017 CS021 CS024 CS026 CS028 CS030 CS031 CS032 CS101 CS103 CS201 CS301 CS302 CS401 CS501 RS106 RS205 RS208 RS210 RS305 RS306 RS307 RS310 RS406 RS407 RS409 RS503 RS508 RS509 DE601 DE602 DE603 DE604 DE605 FR606 SE607 UK608 DE609 PL610 PL611 PL612 IE613 LV614 FI901 )
+
+# Chose a branch of the LOFAR repo to scrape
+branch="master"
+
+# Get antenna CSV information
+for stn in "${STATIONS[@]}"; do
+	echo "Downloading antenna CSV for $stn"
+	lowerstn=$(echo ${stn} | awk '{print tolower($0)}')
+	curl --silent "https://git.astron.nl/ro/lofar/-/raw/${branch}/MAC/Deployment/data/Coordinates/ETRF_FILES/${stn}/${lowerstn}-antenna-positions-etrs.csv" --output "${lowerstn}-antenna-positions-etrs.csv";
+done
+
+
+# Get the StationInfo.dat file
+if [ ! -f "StationInfo.dat" ]; then
+	curl --silent "https://git.astron.nl/ro/lofar/-/raw/${branch}/MAC/Deployment/data/StaticMetaData/StationInfo.dat" --output "StationInfo.dat"
+fi
+
+
+# Run the extraction scripts
+rm -f ../share/lofarantpos/stationinfo-tmp.csv
+./extract-cabinet-positions.py
+
+./extract-etrs-antenna-positions.sh
+./extract-etrs-phase-centres.sh
+
+
+# Cleanup working directory if NO_CLEANUP is not defined
+if [ -z ${NO_CLEANUP+x} ]; then
+	rm -f "StationInfo.dat"
+	for stn in "${STATIONS[@]}"; do
+		lowerstn=$(echo ${stn} | awk '{print tolower($0)}')
+		rm ${lowerstn}-antenna-positions-etrs.csv
+	done
+fi


### PR DESCRIPTION
Hi Michiel,

I was running into a few issues while getting the entries for IE613, and when I tried to upload the CSVs in share/lofarantpos I noticed these scripts were a bit broken, so I've updated them to

- Scrape the raw CSVs from the ASTRON git repo
- Work around an issue in some of the core stations phase centre definitions adding an extra space for the joint phase centre (see CS001 vs CS002 CHBA entry as an example)
- Generate the output entries in share/lofarantpos with a -tmp suffix to make noting the changes easier

This does generate a slight difference in the ordering of HBA phase centre entries (see the other PR,  #13 ), but that should just be a cosmetic effect.

Cheers,
David