### PR TITLE
HBAT has different element offsets in DE601

### DIFF
--- a/lofarantpos/db.py
+++ b/lofarantpos/db.py
@@ -233,7 +233,7 @@ class LofarAntennaDatabase(object):
        
         if field_name[:5] == "DE601":
             # DE601 has different HBAT element offsets
-            base_tile = base_tile.dot([[0, 1.0, 0], [-1.0, 0, 0], [0, 0, 1.0]])
+            base_tile = base_tile.dot([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
        
         base_tile *= 1.25
         base_tile_delta_pqr = base_tile.reshape((-1, 2))

--- a/lofarantpos/db.py
+++ b/lofarantpos/db.py
@@ -230,6 +230,11 @@ class LofarAntennaDatabase(object):
                                  [[-1.5, -0.5], [-0.5, -0.5], [+0.5, -0.5], [+1.5, -0.5]],
                                  [[-1.5, -1.5], [-0.5, -1.5], [+0.5, -1.5], [+1.5, -1.5]]],
                                 dtype=numpy.float32)
+       
+        if field_name[:5] == "DE601":
+            # DE601 has different HBAT element offsets
+            base_tile = base_tile.dot([[0, 1.0, 0], [-1.0, 0, 0], [0, 0, 1.0]])
+       
         base_tile *= 1.25
         base_tile_delta_pqr = base_tile.reshape((-1, 2))
 


### PR DESCRIPTION
See https://git.astron.nl/ro/lofar/-/blob/6715ee4113d3237fb8fab2be939a76863e74d6ce/MAC/Deployment/data/Coordinates/calc_hba_deltas.py#L148

I do not know the historical reasons for this, except that DE601 was the first non-Dutch station and has more minor oddities.